### PR TITLE
Change access flag name to file mode and removed size argument from write_blk

### DIFF
--- a/src/test/test.c
+++ b/src/test/test.c
@@ -76,10 +76,10 @@ int main(int argc, char* argv[]) {
 		exit(1);
 	}
 	printf("Root Directory Inode:\n");
-	uint16_t flags = root_directory_inode.access_flags;
+	uint16_t f_mode = root_directory_inode.file_mode;
 	uint64_t dir_size = root_directory_inode.file_size;
-	printf("\tFile type: %d\n", (flags & F_TYPE_BITS) >> 12);
-	printf("\tFile perm: %o\n", flags & F_PERM_BITS);
+	printf("\tFile type: %d\n", (f_mode & F_TYPE_BITS) >> 12);
+	printf("\tFile perm: %o\n", f_mode & F_PERM_BITS);
 	printf("\tDir size (raw): %lu\n", dir_size);
 
 	// ----- Read freelist head using super blk info -----
@@ -133,9 +133,9 @@ int main(int argc, char* argv[]) {
 		exit(1);
 	}
 	printf("Random Inode:\n");
-	flags = random_inode.access_flags;
-	printf("\tFile type: %d\n", (flags & F_TYPE_BITS) >> 12);
-	printf("\tFile perm: %o\n", flags & F_PERM_BITS);
+	f_mode = random_inode.file_mode;
+	printf("\tFile type: %d\n", (f_mode & F_TYPE_BITS) >> 12);
+	printf("\tFile perm: %o\n", f_mode & F_PERM_BITS);
 	printf("\tDir size (raw): %lu\n", random_inode.file_size);
 
 	close(fd);

--- a/src/uwufs/file_operations.c
+++ b/src/uwufs/file_operations.c
@@ -10,7 +10,7 @@
 #include <errno.h>
 #include <string.h>
 
-ssize_t create_file(uwufs_blk_t *inode, uwufs_aflags_t flags)
+ssize_t create_file(uwufs_blk_t *inode, uint16_t mode)
 {
 	// TODO:
 	return -1;

--- a/src/uwufs/file_operations.h
+++ b/src/uwufs/file_operations.h
@@ -12,13 +12,13 @@
 
 // TODO: Not Implemented yet (feel free to change function signature)
 /**
- * Creates a file using access_flags. The resulting file inode is
+ * Creates a file using file mode. The resulting file inode is
  * 		saved in `inode` output var
  *
  * `inode`: output var for inode of newly created file
  * `flags`: file type/permissions
  */
-ssize_t create_file(uwufs_blk_t *inode, uwufs_aflags_t flags);
+ssize_t create_file(uwufs_blk_t *inode, uint16_t mode);
 
 /**
  * Assumes the caller has already allocated a directory data blk.

--- a/src/uwufs/low_level_operations.c
+++ b/src/uwufs/low_level_operations.c
@@ -32,7 +32,6 @@ debug_msg_ret:
 
 ssize_t write_blk(int fd,
 				  const void* buf,
-				  size_t size,
 				  uwufs_blk_t blk_num)
 {
 	ssize_t status = lseek(fd, blk_num * UWUFS_BLOCK_SIZE, SEEK_SET);
@@ -101,7 +100,7 @@ ssize_t write_inode(int fd,
 
 	memcpy(&inode_blk.inodes[inode_num_in_blk], buf, size);
 
-	status = write_blk(fd, &inode_blk, UWUFS_BLOCK_SIZE, inode_blk_num);
+	status = write_blk(fd, &inode_blk, inode_blk_num);
 	if (status < 0)
 		goto debug_msg_ret;
 
@@ -136,7 +135,7 @@ ssize_t malloc_blk(int fd, uwufs_blk_t *blk_num)
 		goto debug_msg_ret;
 
 	super_blk.freelist_head = free_blk.next_free_blk;
-	status = write_blk(fd, &super_blk, UWUFS_BLOCK_SIZE, 0);
+	status = write_blk(fd, &super_blk, 0);
 	if (status < 0)
 		goto debug_msg_ret;
 
@@ -162,11 +161,11 @@ ssize_t free_blk(int fd, const uwufs_blk_t blk_num)
 	new_freelist_head.next_free_blk = super_blk.freelist_head;
 	super_blk.freelist_head = blk_num;
 
-	status = write_blk(fd, &new_freelist_head, UWUFS_BLOCK_SIZE, blk_num);
+	status = write_blk(fd, &new_freelist_head, blk_num);
 	if (status < 0)
 		goto debug_msg_ret;
 
-	status = write_blk(fd, &super_blk, UWUFS_BLOCK_SIZE, 0);
+	status = write_blk(fd, &super_blk, 0);
 	if (status < 0)
 		goto debug_msg_ret;
 

--- a/src/uwufs/low_level_operations.h
+++ b/src/uwufs/low_level_operations.h
@@ -16,7 +16,7 @@
  * The block size is determined by UWUFS_BLOCK_SIZE (see uwufs.h)
  *
  * `fd`: block device
- * `buf`: output var to be read into (must be at least UWUFS_BLOCK_SIZE)
+ * `buf`: output var to be read into (size must be at least UWUFS_BLOCK_SIZE)
  * `blk_num`: block number to be read
  */
 ssize_t read_blk(int fd, void* buf, uwufs_blk_t blk_num);
@@ -26,11 +26,10 @@ ssize_t read_blk(int fd, void* buf, uwufs_blk_t blk_num);
  * The buf size must be exactly UWUFS_BLOCK_SIZE (see uwufs.h)
  *
  * `fd`: block device
- * `buf`: data to write to block device (must be exactly UWUFS_BLOCK_SIZE)
- * `size`: must be UWUFS_BLOCK_SIZE (might change if implementation changes)
+ * `buf`: data to write to block device (size must be UWUFS_BLOCK_SIZE)
  * `blk_num`: block number to write to
  */
-ssize_t write_blk(int fd, const void* buf, size_t size, uwufs_blk_t blk_num);
+ssize_t write_blk(int fd, const void* buf, uwufs_blk_t blk_num);
 
 /**
  * Reads an inode from the specified block device.

--- a/src/uwufs/syscalls.c
+++ b/src/uwufs/syscalls.c
@@ -53,7 +53,7 @@ int uwufs_getattr(const char *path,
 		return -ENOENT;
 
 	// TODO: Fill in other file types and flags (not implemented yet)
-	uwufs_aflags_t flags = inode.access_flags;
+	uint16_t flags = inode.file_mode;
 	switch (flags & F_TYPE_BITS) {
 		case F_TYPE_DIRECTORY:
 			stbuf->st_mode = S_IFDIR | (flags & F_PERM_BITS);
@@ -158,7 +158,7 @@ int uwufs_readdir(const char *path,
 	if (status < 0)
 		return -ENOENT;
 
-	uwufs_aflags_t aflags = inode.access_flags;
+	uint16_t aflags = inode.file_mode;
 	if (F_TYPE_DIRECTORY != (aflags & F_TYPE_BITS))
 		return -ENOTDIR;
 

--- a/src/uwufs/uwufs.h
+++ b/src/uwufs/uwufs.h
@@ -28,8 +28,8 @@
 // Total file entry in a directory is 64 bytes
 #define UWUFS_FILE_NAME_SIZE			56
 
-/* File access flags */
-typedef uint16_t uwufs_aflags_t;
+/* File access mode */
+typedef uint16_t uwufs_aflags_t; // Deprecated (use uint16_t directly)
 // File types
 #define F_TYPE_BITS						0b1111000000000000
 // NOTE: Might change to match stat.h file types?
@@ -72,7 +72,7 @@ struct __attribute__((__packed__)) uwufs_inode {
 	uwufs_blk_t single_indirect_blks;
 	uwufs_blk_t double_indirect_blks;
 	uwufs_blk_t triple_indirect_blks;
-	uwufs_aflags_t access_flags; 		// file types/permissions
+	uint16_t file_mode; 		// file types/permissions
 	uint64_t file_size;
 	// TODO: owner, num of links, etc
 	


### PR DESCRIPTION
Changes:
- Renamed `access_flag` name to `file_mode` for clarity
- Deprecated `uwufs_aflags_t` (please use uint16_t directly)
- Removed write size argument from `write_blk` function for clarity. In other words, `read_blk` and `write_blk` fully enforces read and write operations in 4096 byte blocks (UWUFS_BLOCK_SIZE)